### PR TITLE
Set default tags parameter passed in ansible as list

### DIFF
--- a/column/api_runner.py
+++ b/column/api_runner.py
@@ -16,6 +16,7 @@ from ansible.utils.vars import load_extra_vars
 from ansible.vars import VariableManager
 
 from column import callback
+from column import exceptions
 from column import runner
 
 
@@ -187,6 +188,13 @@ class APIRunner(runner.Runner):
         }
         args.update(self.custom_opts)
         args.update(kwargs)
+        # In ansible 2.2, tags can be a string or a list, but only a list
+        # is supported in 2.3.
+        if isinstance(args['tags'], str):
+            args['tags'] = args['tags'].split(',')
+        elif not isinstance(args['tags'], list):
+            raise exceptions.InvalidParameter(name=type(args['tags']).__name__,
+                                              param='tag')
         return Namespace(**args)
 
     def _play_ds(self, hosts, module_name, module_args):

--- a/column/exceptions.py
+++ b/column/exceptions.py
@@ -1,0 +1,30 @@
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+class BaseException(Exception):
+    """The Base Exception to extend custom exceptions.
+    """
+
+    message = "An unknown exception occurred."
+
+    def __init__(self, msg=None, **kwargs):
+        if msg:
+            self.message = msg
+        if kwargs:
+            try:
+                self.msg = self.message % kwargs
+            except KeyError as e:
+                LOG.warning("Formatting error: %(e)s. Message: "
+                            "%(msg)s. kwargs: %(kwargs)s",
+                            {'e': e, 'msg': self.message, 'kwargs': kwargs})
+                self.msg = self.message
+        else:
+            self.msg = self.message
+        super(BaseException, self).__init__(self.msg)
+
+
+class InvalidParameter(BaseException):
+    """Invalid parameter given"""
+    message = "Invalid type of %(name)s on parameter %(param)s"


### PR DESCRIPTION
In ansible 2.2, there is checking for tags, which means it could be
a string or a list.

https://github.com/ansible/ansible/blob/v2.2.1.0-1/lib/ansible/playbook/play_context.py#L295

However in ansible 2.3, there is no checking. So only a list of
tags is supported.

Signed-off-by: Eric Brown <browne@vmware.com>