### PR TITLE
Add travis ability to deploy to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-  - "2.7"
+  - '2.7'
+
 # command to install dependencies
 install:
   - pip install -r requirements.txt
@@ -9,3 +10,12 @@ install:
 
 # command to run tests
 script: tox
+
+deploy:
+  provider: pypi
+  user: vmware.column
+  password:
+    secure: wjMFZ2ifNY28n4nTLvuH4biSvIP1iynSrB/bzQZW5MFIQ1edm0RsEaDfE7KQoHufoc/3BYGShqhIvQHySxg05eZBAJhelMTiCHleD7zRvMv0KG8f29qFojWjnUBxV4i4WjSOmGyHiFRdlr9BG9m4zZ4K8qBsUQG9NRTFNi7s5iBWc7SULzpYDcrvIQJ2NVrL+qysBRBFPXJeCX/UuxVEQePtM73TMBQwWCN4mYIHq3eHBLrEnqhDhLjYdEpagvDpABKJ7MGS4g6L5ESuPbcf7Ng41ZDU/DmVYhcN+X9bt6BHKVkzbsihdAkoisQOv/bjvvzH6RV0dev2RnjOc83svAFuOa/a6shErN+CAANoFvf2jIJwIt8FM6MY1fEGyBhnp9Q9i4Cb3GIjtXrURcdOWx/yyn1Drc4DyYfsI0wt9IKghQ7yO1BRSwlKSFx3rhJFn0SN6Sh7bq2ckm/dPGnOLQbNSrpkBYphvBcrXXcjukoyJD4urh2hs+eTrkbDouUzxwRkPGFmq/ttJ3JRg25tVjj5dnk1MtQDTaGTHKCrj10vbh/wo9E89xqnV+kS19vIHM0Duvt89fifc5XoSC+SWrkVeOxxpSZhKtrubk9dSKfz0xLaefPIMLQZg7B+ldYX0lqTOyGhZyJIAm/47fXbMPl2UN+5W+rATzljLHpOF8c=
+  on:
+    tags: true
+    distributions: sdist bdist_wheel


### PR DESCRIPTION
Following instructions from https://docs.travis-ci.com/user/deployment/pypi/ on how to tell Travis to automatically deploy to PyPi on a tag.

Signed-off-by: Eric Brown <browne@vmware.com>