### PR TITLE
Simplify the vault utility functions 

### DIFF
--- a/column/utils.py
+++ b/column/utils.py
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 
-import logging
 import os
-import stat
 
 from ansible import cli
 from ansible import constants
@@ -13,37 +11,25 @@ from ansible.parsing import vault
 from ansible.utils import display
 
 
-LOG = logging.getLogger(__name__)
-
-
 def reload_log_path(log_path):
     os.environ['ANSIBLE_LOG_PATH'] = log_path
     reload(constants)
     reload(display)
 
 
-def get_vault_secret(secret_file):
+def vault_decrypt(value):
     reload(constants)
     vault_password = cli.CLI.read_vault_password_file(
         constants.DEFAULT_VAULT_PASSWORD_FILE, dataloader.DataLoader())
 
     this_vault = vault.VaultLib(vault_password)
-
-    with open(secret_file) as f:
-        return this_vault.decrypt(f.read())
+    return this_vault.decrypt(value)
 
 
-def update_vault_secret(secret_file, value):
+def vault_encrypt(value):
     reload(constants)
     vault_password = cli.CLI.read_vault_password_file(
         constants.DEFAULT_VAULT_PASSWORD_FILE, dataloader.DataLoader())
 
-    if vault_password:
-        this_vault = vault.VaultLib(vault_password)
-        enc_data = this_vault.encrypt(value)
-
-        with open(secret_file, 'wb') as f:
-            os.chmod(secret_file, stat.S_IRUSR | stat.S_IWUSR)
-            f.write(enc_data)
-    else:
-        LOG.debug('No vault_password found')
+    this_vault = vault.VaultLib(vault_password)
+    return this_vault.encrypt(value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2017 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-import mock
 from mock import patch
 
 from testtools import TestCase
@@ -36,7 +35,7 @@ class TestUtils(TestCase):
             '3933\n'
         )
         mock_read_vault_password.return_value = self.vault_password
-        self.assertEquals('vmware', utils.vault_decrypt(encrypted_value))
+        self.assertEqual('vmware', utils.vault_decrypt(encrypted_value))
         self.assertTrue(mock_read_vault_password.called)
 
     @patch('__builtin__.reload')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ class TestUtils(TestCase):
 
     def setUp(self):
         super(TestUtils, self).setUp()
+        self.vault_password = 'h2RV4pEX2M2TXvLxYhuy'
 
     @patch('__builtin__.reload')
     def test_reload_log_path(self, mock_reload):
@@ -21,26 +22,27 @@ class TestUtils(TestCase):
 
     @patch('__builtin__.reload')
     @patch('ansible.cli.CLI.read_vault_password_file')
-    @patch('ansible.parsing.vault.VaultLib')
-    @patch('ansible.parsing.vault.VaultLib.decrypt')
-    @patch('__builtin__.open', mock.mock_open(), create=True)
-    def test_get_vault_secret(self, mock_decrypt, mock_vaultlib,
-                              mock_read_vault_password_file, mock_reload):
-        mock_read_vault_password_file.return_value = 'my_vault_password'
-        utils.get_vault_secret('/var/lib/column/admin_password')
-        self.assertTrue(mock_read_vault_password_file.called)
-        mock_vaultlib.assert_called_with('my_vault_password')
+    def test_vault_decrypt(self, mock_read_vault_password, mock_reload):
+        encrypted_value = (
+            '$ANSIBLE_VAULT;1.1;AES256\n'
+            '3139663233656537383737613633343638313934'
+            '3033363766663532326434386435376639316434\n'
+            '3930306333303835316564373530656365376561'
+            '356466330a383238373762656238336432373261\n'
+            '6230306330646332393932316536323235323561'
+            '3038386232636331363931373538626461396364\n'
+            '6338336334343366650a35363165316661666236'
+            '3637636234666230333764323361643866643863\n'
+            '3933\n'
+        )
+        mock_read_vault_password.return_value = self.vault_password
+        self.assertEquals('vmware', utils.vault_decrypt(encrypted_value))
+        self.assertTrue(mock_read_vault_password.called)
 
     @patch('__builtin__.reload')
     @patch('ansible.cli.CLI.read_vault_password_file')
-    @patch('ansible.parsing.vault.VaultLib')
-    @patch('ansible.parsing.vault.VaultLib.encrypt')
-    @patch('__builtin__.open', mock.mock_open(), create=True)
-    @patch('os.chmod')
-    def test_update_vault_secret(self, mock_chmod, mock_encrypt, mock_vaultlib,
-                                 mock_read_vault_password_file, mock_reload):
-        mock_read_vault_password_file.return_value = 'my_vault_password'
-        utils.update_vault_secret('/var/lib/column/admin_password', 'pass')
-        self.assertTrue(mock_read_vault_password_file.called)
-        mock_vaultlib.assert_called_with('my_vault_password')
-        self.assertTrue(mock_chmod.called)
+    def test_vault_encrypt(self, mock_read_vault_password, mock_reload):
+        mock_read_vault_password.return_value = self.vault_password
+        encrypted = utils.vault_encrypt('vmware')
+        self.assertTrue(encrypted.startswith('$ANSIBLE_VAULT;1.1;AES256'))
+        self.assertTrue(mock_read_vault_password.called)


### PR DESCRIPTION
Manipulating files is not necessary in these APIs.

* Renamed get_vault_secret to vault_decrypt
* Renamed update_vault_secret to vault_encrypt
* Fixed up the unit tests to validate real data and less mocking

Signed-off-by: Eric Brown <browne@vmware.com>