### PR TITLE
Update cryptography version not equal to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ flask
 flask_restful
 six
 jsonschema
+# 2.0.1 breaks py27 tests
+# https://github.com/vmware/column/issues/107
+cryptography!=2.0.1


### PR DESCRIPTION
latest 2.0.1 will break py27 test