### PR TITLE
Fix Dockerfile to bind to all container interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,7 @@ RUN apt-get update -y && apt-get install -y\
 COPY . /app
 WORKDIR /app
 RUN pip install -r requirements.txt && python setup.py install
+COPY ./etc/column/column-docker.conf /etc/column/column.conf
+EXPOSE 48620
 ENTRYPOINT ["python"]
 CMD ["column/api/run.py"]

--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ uwsgi --socket 0.0.0.0:48620 --protocol=http -w column.api.wsgi
 
 ## Running in Docker
 ```docker
-1. Update 127.0.0.1 to 0.0.0.0 in the etc/column/column.conf file
-2. docker build -t column-image .
-3. docker run -d -p 48620:48620 -v <playbook-dir>:<container-dir> column-image (the directory should contain the playbook file)
+1. docker build -t column-image .
+2. docker run -d -p 48620:48620 -v <playbook-dir>:<container-dir> column-image (the directory should contain the playbook file)
 ```
 
 ## Documentation

--- a/etc/column/column-docker.conf
+++ b/etc/column/column-docker.conf
@@ -1,0 +1,13 @@
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+[DEFAULT]
+# Log file
+log_file = /var/log/column/column.log
+
+# Log info level
+log_level = DEBUG
+
+# API config
+server = 0.0.0.0
+port = 48620


### PR DESCRIPTION
When running a service in a container, it's by default bound to
all interfaces. The publish option in 'docker run' controls how
the port is exposed to the host. e.g

docker run -p 127.0.0.1:48620:48620 will publish the port
only to the host's loopback address.

docker run -p 48620:48620 will publish the port to all interfaces.

Hence, fix the docker build file to always bind to 0.0.0.0
inside the container.

Signed-off-by: Sabari Kumar Murugesan <smurugesan@vmware.com>