### PR TITLE
Fix no /var/log/column/column.log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ RUN apt-get update -y && apt-get install -y\
     libffi-dev
 COPY . /app
 WORKDIR /app
-RUN pip install -r requirements.txt && python setup.py install
+RUN pip install -r requirements.txt \
+&& python setup.py install \
+&& mkdir -p /var/log/column \
+&& touch /var/log/column/column.log
 COPY ./etc/column/column-docker.conf /etc/column/column.conf
 EXPOSE 48620
 ENTRYPOINT ["python"]


### PR DESCRIPTION
The current code check for whether the /var/log/column/column.log
is writable, otherwise column won't create LOG and no logs will
be generated.

Update Dockerfile to create /var/log/column/column.log