### PR TITLE
Add capability for newer Ansible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.2.0.0,<2.4.0
+ansible>=2.2.0.0
 flask
 flask_restful
 six


### PR DESCRIPTION
Currently Column is restricted to version 2.2.x to less than 2.4.
This patch is to fix problems associated with version 2.4 and above,
so that we are current again.

Signed-off-by: Eric Brown <browne@vmware.com>