### PR TITLE
Fix up some pylint nits on variables

### DIFF
--- a/column/__init__.py
+++ b/column/__init__.py
@@ -20,12 +20,12 @@ __all__ = [
 
 __version__ = '0.5.2'
 
-defaults = {
+DEFAULTS = {
     'log_file': os.path.join(os.sep, 'var', 'log', 'column.log'),
     'log_level': 'DEBUG',
     'server': '127.0.0.1',
     'port': '48620'
 }
 
-cfg = configparser.ConfigParser(defaults)
+cfg = configparser.ConfigParser(DEFAULTS)
 cfg.read(DEFAULT_CONF_FILE)

--- a/column/api/__init__.py
+++ b/column/api/__init__.py
@@ -6,4 +6,4 @@ import copy
 from ansible.playbook import play_context
 
 
-context_attributes = copy.deepcopy(play_context.PlayContext._attributes)
+CONTEXT_ATTRIBUTES = copy.deepcopy(play_context.PlayContext._attributes)

--- a/column/api/manager/run_manager.py
+++ b/column/api/manager/run_manager.py
@@ -75,7 +75,7 @@ class RunManager(object):
 
     def _run_playbook(self, run):
         play_context.PlayContext._attributes = copy.deepcopy(
-            api.context_attributes)
+            api.CONTEXT_ATTRIBUTES)
         column_opts = self._build_opts(run)
         progress_callback = progress.AnsibleTrackProgress()
         self.column_manager.add_callback(progress_callback)

--- a/column/api_runner.py
+++ b/column/api_runner.py
@@ -106,7 +106,7 @@ class APIRunner(runner.Runner):
         # property to add callbacks
         pbex._tqm._callback_plugins.extend(self._callbacks)
         try:
-            status = pbex.run()
+            pbex.run()
         except errors.AnsibleParserError as e:
             raise exceptions.ParsePlaybookError(msg=str(e))
         stats = pbex._tqm._stats


### PR DESCRIPTION
Pylint is flagging the names of variables used in some files.

Namely, it warns "Invalid Constant Name" where a constant is not
defined as all caps.

This patch also removes an unused variable.

Signed-off-by: Eric Brown <browne@vmware.com>