### PR TITLE
Add a util to get the ansible version

### DIFF
--- a/column/utils.py
+++ b/column/utils.py
@@ -7,6 +7,7 @@ from ansible import cli
 from ansible import errors
 from ansible.parsing import dataloader
 from ansible.parsing import vault
+from ansible import release
 from six.moves import configparser
 
 
@@ -39,3 +40,7 @@ def vault_encrypt(value):
         _get_vault_password_file(), dataloader.DataLoader())
     this_vault = vault.VaultLib(vault_password)
     return this_vault.encrypt(value)
+
+
+def ansible_version():
+    return release.__version__


### PR DESCRIPTION
This patch adds a new funtion to the utils that allows code to
fetch the ansible version being linked with. That way, the column
code can branch based on ansible version.

Signed-off-by: Eric Brown <browne@vmware.com>