### PR TITLE
Add test jobs for Python 3.x versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0
 
 language: python
-python:
-  - "2.7_with_system_site_packages"
 
-dist:
-  - xenial
+sudo: false
 
 # command to install dependencies
 install:
@@ -15,6 +12,25 @@ install:
 
 # command to run tests
 script: tox
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=pep8
+      dist: xenial
+    - python: 2.7
+      env: TOXENV=py27
+      dist: xenial
+    - python: 3.5
+      env: TOXENV=py35
+      dist: xenial
+    - python: 3.6
+      env: TOXENV=py36
+      dist: xenial
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial
+      sudo: true
 
 after_success:
   - codecov -e $TRAVIS_PYTHON_VERSION


### PR DESCRIPTION
Currently Column supports just Python 2.7, but Ansible now supports
3.x, so should Column. This patch makes use of the Travis-CI matrix.

Note: Python 3.7 currently requires sudo: true. This will probably
be fixed by travis-ci later.

Signed-off-by: Eric Brown <browne@vmware.com>