### PR TITLE
Use six.moves.reload_module() instead of builtin

### DIFF
--- a/column/api_runner.py
+++ b/column/api_runner.py
@@ -4,7 +4,6 @@
 import json
 import logging
 import os
-import six
 
 from ansible import constants
 from ansible import errors
@@ -15,6 +14,7 @@ from ansible.parsing import dataloader
 from ansible.parsing.splitter import parse_kv
 from ansible.playbook import play
 from ansible import vars
+import six
 
 from column import callback
 from column import exceptions
@@ -55,7 +55,7 @@ class APIRunner(runner.Runner):
         return None
 
     def run_playbook(self, playbook_file, inventory_file=None, **kwargs):
-        reload(constants)
+        six.moves.reload_module(constants)
 
         if not os.path.isfile(playbook_file):
             raise exceptions.FileNotFound(name=playbook_file)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ class TestUtils(TestCase):
         super(TestUtils, self).setUp()
         self.vault_password = 'h2RV4pEX2M2TXvLxYhuy'
 
-    @patch('__builtin__.reload')
+    @patch('six.moves.reload_module')
     @patch('column.utils._read_vault_password_file')
     def test_vault_decrypt(self, mock_read_vault_password):
         encrypted_value = (
@@ -33,7 +33,7 @@ class TestUtils(TestCase):
         self.assertEqual('vmware', utils.vault_decrypt(encrypted_value))
         self.assertTrue(mock_read_vault_password.called)
 
-    @patch('__builtin__.reload')
+    @patch('six.moves.reload_module')
     @patch('column.utils._read_vault_password_file')
     def test_vault_encrypt(self, mock_read_vault_password, mock_reload):
         mock_read_vault_password.return_value = self.vault_password


### PR DESCRIPTION
The reload() builtin module of Python only exists in Python 2.x.
The docs state to use importlib.reload() in 3.x. But in order to
best support both, this patch makes use of the six.moves.reload_module()
module.

Fixes issue #195

Signed-off-by: Eric Brown <browne@vmware.com>