### PR TITLE
Remove blurb from README about Python3 and Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ run_playbook() and run_module().
 ## Try it out
 
 ### Prerequisites
-* python 2.7 (python 3 is not fully supported by ansible)
+* python 2.7
 * ansible 2.x
 * six library
 


### PR DESCRIPTION
Ansible 2.5+ supports Python 3, thereby making the statement in
the README incorrect.

Fixes #197

Signed-off-by: Eric Brown <browne@vmware.com>